### PR TITLE
[SGrid] Fix Equip item Celestial/Soul, [newApp] Correção das cores Itemhelp

### DIFF
--- a/Projects/TMProject/Basedef.cpp
+++ b/Projects/TMProject/Basedef.cpp
@@ -1815,7 +1815,7 @@ int BASE_CanCargo(STRUCT_ITEM* item, STRUCT_ITEM* cargo, int DestX, int DestY)
     return 1;
 }
 
-int BASE_CanEquip(STRUCT_ITEM* item, STRUCT_SCORE* score, int Pos, int Class, STRUCT_ITEM* pBaseEquip, int OriginalFace, int cktrans)
+int BASE_CanEquip(STRUCT_ITEM* item, STRUCT_SCORE* score, int Pos, int Class, STRUCT_ITEM* pBaseEquip, int OriginalFace, bool checkTrans)
 {
     int idx = item->sIndex;
     if (idx <= 0 || idx >= 6500)
@@ -1893,7 +1893,7 @@ int BASE_CanEquip(STRUCT_ITEM* item, STRUCT_SCORE* score, int Pos, int Class, ST
     case 3:
         if (trans < 6)
             return FALSE;
-        if (cktrans != 1)
+        if (!checkTrans)
             return FALSE;
         break;
     }

--- a/Projects/TMProject/Basedef.cpp
+++ b/Projects/TMProject/Basedef.cpp
@@ -1815,7 +1815,7 @@ int BASE_CanCargo(STRUCT_ITEM* item, STRUCT_ITEM* cargo, int DestX, int DestY)
     return 1;
 }
 
-int BASE_CanEquip(STRUCT_ITEM* item, STRUCT_SCORE* score, int Pos, int Class, STRUCT_ITEM* pBaseEquip, int OriginalFace, bool checkTrans)
+int BASE_CanEquip(STRUCT_ITEM* item, STRUCT_SCORE* score, int Pos, int Class, STRUCT_ITEM* pBaseEquip, int OriginalFace, bool hasSoulLimitSkill)
 {
     int idx = item->sIndex;
     if (idx <= 0 || idx >= 6500)
@@ -1893,7 +1893,7 @@ int BASE_CanEquip(STRUCT_ITEM* item, STRUCT_SCORE* score, int Pos, int Class, ST
     case 3:
         if (trans < 6)
             return FALSE;
-        if (!checkTrans)
+        if (!hasSoulLimitSkill)
             return FALSE;
         break;
     }

--- a/Projects/TMProject/Basedef.h
+++ b/Projects/TMProject/Basedef.h
@@ -144,6 +144,11 @@ struct STRUCT_MOB
 	char dummy[212];
 	unsigned short CurrentKill;
 	unsigned short TotalKill;
+
+	bool HasSoulSkill() const
+	{
+		return this->LearnedSkill[0] & 0x40000000;
+	}
 };
 
 struct STRUCT_AFFECT
@@ -2891,7 +2896,7 @@ int BASE_CanTrade(STRUCT_ITEM* Dest, STRUCT_ITEM* Carry, char* MyTrade, STRUCT_I
 void BASE_ClearItem(STRUCT_ITEM* item);
 void BASE_SortTradeItem(STRUCT_ITEM* Item, int Type);
 int BASE_CanCargo(STRUCT_ITEM* item, STRUCT_ITEM* cargo, int DestX, int DestY);
-int BASE_CanEquip(STRUCT_ITEM* item, STRUCT_SCORE* score, int Pos, int Class, STRUCT_ITEM* pBaseEquip, int OriginalFace, int cktrans);
+int BASE_CanEquip(STRUCT_ITEM* item, STRUCT_SCORE* score, int Pos, int Class, STRUCT_ITEM* pBaseEquip, int OriginalFace, bool skillCheck);
 unsigned int BASE_GetItemColor(STRUCT_ITEM* item);
 int BASE_GetColorCount(unsigned int dwColor);
 int BASE_GetManaSpent(int SkillNumber, int SaveMana, int Special);

--- a/Projects/TMProject/Basedef.h
+++ b/Projects/TMProject/Basedef.h
@@ -2896,7 +2896,7 @@ int BASE_CanTrade(STRUCT_ITEM* Dest, STRUCT_ITEM* Carry, char* MyTrade, STRUCT_I
 void BASE_ClearItem(STRUCT_ITEM* item);
 void BASE_SortTradeItem(STRUCT_ITEM* Item, int Type);
 int BASE_CanCargo(STRUCT_ITEM* item, STRUCT_ITEM* cargo, int DestX, int DestY);
-int BASE_CanEquip(STRUCT_ITEM* item, STRUCT_SCORE* score, int Pos, int Class, STRUCT_ITEM* pBaseEquip, int OriginalFace, bool skillCheck);
+int BASE_CanEquip(STRUCT_ITEM* item, STRUCT_SCORE* score, int Pos, int Class, STRUCT_ITEM* pBaseEquip, int OriginalFace, bool hasSoulLimitSkill);
 unsigned int BASE_GetItemColor(STRUCT_ITEM* item);
 int BASE_GetColorCount(unsigned int dwColor);
 int BASE_GetManaSpent(int SkillNumber, int SaveMana, int Special);

--- a/Projects/TMProject/NewApp.cpp
+++ b/Projects/TMProject/NewApp.cpp
@@ -364,7 +364,7 @@ HRESULT NewApp::Initialize(HINSTANCE hInstance, int nFull)
 			else
 			{
 				memset(szCol, 0, 8);
-				strncpy(szCol, szTemp, 8);
+				strncpy(szCol, szTemp, 6);
 				sscanf(szCol, "%x", &Color);
 				char* szRet = strstr(szTemp, "\n");
 				if (szRet)
@@ -372,7 +372,7 @@ HRESULT NewApp::Initialize(HINSTANCE hInstance, int nFull)
 				if (szTemp[8] == '\t' || szTemp[8] == ' ')
 					sprintf(g_pItemHelp[ItemIndex].Help[j - 1], "%s", &szTemp[9]);
 
-				g_pItemHelp[ItemIndex].Color[j - 1] = Color;
+				g_pItemHelp[ItemIndex].Color[j - 1] = static_cast<short>(Color);
 			}
 		}
 		++NumHelp;

--- a/Projects/TMProject/SGrid.cpp
+++ b/Projects/TMProject/SGrid.cpp
@@ -403,12 +403,8 @@ int SGridControl::OnMouseEvent(unsigned int dwFlags, unsigned int wParam, int nX
 
 				if (sDestPos == -1)
 				{
-					int cktrans = 0;
-					if (pMobData->LearnedSkill[0] & 0x40000000)
-						cktrans = 1;
-
 					if (!BASE_CanEquip(pItem->m_pItem, &pMobData->CurrentScore, sDestPos, pMobData->Equip[0].sIndex, pMobData->Equip, 
-						g_pObjectManager->m_stSelCharData.Equip[g_pObjectManager->m_cCharacterSlot][0].sIndex, cktrans))
+						g_pObjectManager->m_stSelCharData.Equip[g_pObjectManager->m_cCharacterSlot][0].sIndex, pMobData->HasSoulSkill()))
 						return 0;
 
 					if (NewItemPos >= 64 && NewItemPos <= 192)
@@ -421,9 +417,6 @@ int SGridControl::OnMouseEvent(unsigned int dwFlags, unsigned int wParam, int nX
 						unsigned int nWeaponLPos = BASE_GetItemAbility(&itemL, 17);
 						unsigned int nWeaponRPos = BASE_GetItemAbility(&itemR, 17);
 
-						cktrans = 0;
-						if (pMobData->LearnedSkill[0] & 0x40000000)
-							cktrans = 1;
 
 						if (nWeaponLPos == 64 && nWeaponRPos == 128 && NewItemPos != 128)
 							NewItemPosConv = 6;
@@ -435,7 +428,7 @@ int SGridControl::OnMouseEvent(unsigned int dwFlags, unsigned int wParam, int nX
 							NewItemPosConv = 6;
 
 						if (!BASE_CanEquip(pItem->m_pItem, &pMobData->CurrentScore,	6, pMobData->Equip[0].sIndex, pMobData->Equip,
-							g_pObjectManager->m_stSelCharData.Equip[g_pObjectManager->m_cCharacterSlot][0].sIndex, cktrans) && 
+							g_pObjectManager->m_stSelCharData.Equip[g_pObjectManager->m_cCharacterSlot][0].sIndex, pMobData->HasSoulSkill()) &&
 							NewItemPos != 128)
 						{
 							return 0;
@@ -830,7 +823,7 @@ int SGridControl::CanChangeItem(SGridControlItem* ipNewItem, int inCellIndexX, i
 					pMobData->Equip[0].sIndex,
 					pMobData->Equip,
 					g_pObjectManager->m_stSelCharData.Equip[g_pObjectManager->m_cCharacterSlot][0].sIndex,
-					pMobData->LearnedSkill[0] & 0x40000000 ? 1 : 0);
+					pMobData->HasSoulSkill());
 			}
 			if (nItemType == 64 || nItemType == 192)
 			{
@@ -843,7 +836,7 @@ int SGridControl::CanChangeItem(SGridControlItem* ipNewItem, int inCellIndexX, i
 						pMobData->Equip[0].sIndex,
 						pMobData->Equip,
 						g_pObjectManager->m_stSelCharData.Equip[g_pObjectManager->m_cCharacterSlot][0].sIndex,
-						pMobData->LearnedSkill[0] & 0x40000000 ? 1 : 0)
+						pMobData->HasSoulSkill())
 						&& !bOnlyCheck)
 					{
 						short sDestType = CheckType(ipNewItem->m_pGridControl->m_eItemType, ipNewItem->m_pGridControl->m_eGridType);
@@ -879,7 +872,7 @@ int SGridControl::CanChangeItem(SGridControlItem* ipNewItem, int inCellIndexX, i
 			pMobData->Equip[0].sIndex,
 			pMobData->Equip,
 			g_pObjectManager->m_stSelCharData.Equip[g_pObjectManager->m_cCharacterSlot][0].sIndex,
-			pMobData->LearnedSkill[0] & 0x40000000 ? 1 : 0);
+			pMobData->HasSoulSkill());
 	}
 	else if (sType == 1)
 		return 1;
@@ -3035,13 +3028,10 @@ int SGridControl::MouseOver(int nCellX, int nCellY, int bPtInRect)
 	}
 
 	auto pMobData = &g_pObjectManager->m_stMobData;
-	int cktrans = 0;
-	if (!(pMobData->LearnedSkill[0] & 0x40000000))
-		cktrans = 1;
 
 	unsigned int dwColor = 0;
 	if (BASE_CanEquip(pItem->m_pItem, &pMobData->CurrentScore, -1, pMobData->Equip[0].sIndex, pMobData->Equip,
-		g_pObjectManager->m_stSelCharData.Equip[g_pObjectManager->m_cCharacterSlot][0].sIndex, cktrans))
+		g_pObjectManager->m_stSelCharData.Equip[g_pObjectManager->m_cCharacterSlot][0].sIndex, pMobData->HasSoulSkill()))
 	{
 		dwColor = 0x0FFFFFFFF;
 	}

--- a/Projects/TMProject/SGrid.cpp
+++ b/Projects/TMProject/SGrid.cpp
@@ -404,7 +404,7 @@ int SGridControl::OnMouseEvent(unsigned int dwFlags, unsigned int wParam, int nX
 				if (sDestPos == -1)
 				{
 					int cktrans = 0;
-					if (!(pMobData->LearnedSkill[0] & 0x40000000))
+					if (pMobData->LearnedSkill[0] & 0x40000000)
 						cktrans = 1;
 
 					if (!BASE_CanEquip(pItem->m_pItem, &pMobData->CurrentScore, sDestPos, pMobData->Equip[0].sIndex, pMobData->Equip, 
@@ -422,7 +422,7 @@ int SGridControl::OnMouseEvent(unsigned int dwFlags, unsigned int wParam, int nX
 						unsigned int nWeaponRPos = BASE_GetItemAbility(&itemR, 17);
 
 						cktrans = 0;
-						if (!(pMobData->LearnedSkill[0] & 0x40000000))
+						if (pMobData->LearnedSkill[0] & 0x40000000)
 							cktrans = 1;
 
 						if (nWeaponLPos == 64 && nWeaponRPos == 128 && NewItemPos != 128)
@@ -830,7 +830,7 @@ int SGridControl::CanChangeItem(SGridControlItem* ipNewItem, int inCellIndexX, i
 					pMobData->Equip[0].sIndex,
 					pMobData->Equip,
 					g_pObjectManager->m_stSelCharData.Equip[g_pObjectManager->m_cCharacterSlot][0].sIndex,
-					pMobData->LearnedSkill[0] & 0x40000000);
+					pMobData->LearnedSkill[0] & 0x40000000 ? 1 : 0);
 			}
 			if (nItemType == 64 || nItemType == 192)
 			{
@@ -843,7 +843,7 @@ int SGridControl::CanChangeItem(SGridControlItem* ipNewItem, int inCellIndexX, i
 						pMobData->Equip[0].sIndex,
 						pMobData->Equip,
 						g_pObjectManager->m_stSelCharData.Equip[g_pObjectManager->m_cCharacterSlot][0].sIndex,
-						pMobData->LearnedSkill[0] & 0x40000000) == 1
+						pMobData->LearnedSkill[0] & 0x40000000 ? 1 : 0)
 						&& !bOnlyCheck)
 					{
 						short sDestType = CheckType(ipNewItem->m_pGridControl->m_eItemType, ipNewItem->m_pGridControl->m_eGridType);
@@ -879,7 +879,7 @@ int SGridControl::CanChangeItem(SGridControlItem* ipNewItem, int inCellIndexX, i
 			pMobData->Equip[0].sIndex,
 			pMobData->Equip,
 			g_pObjectManager->m_stSelCharData.Equip[g_pObjectManager->m_cCharacterSlot][0].sIndex,
-			pMobData->LearnedSkill[0] & 0x40000000);
+			pMobData->LearnedSkill[0] & 0x40000000 ? 1 : 0);
 	}
 	else if (sType == 1)
 		return 1;


### PR DESCRIPTION
O jogo atualmente não permite equipar itens celestiais em personagens celestiais. Isto acontece em dois casos diferentes:
- Ctrl+click: Checar se possui soul (que é como o jogo olha para esta situação) está invertida, ou seja, equipando somente em quem não possui soul
- Movimentar item: o método está checando corretamente, mas o método `BASE_CanEquip` recebe um inteiro. O resultado de um AND do Learn ocasiona em algo bem diferente de 1 caso o mesmo possua soul. O parâmetro em questão é um int.