### PR TITLE
Closing files after use

### DIFF
--- a/Projects/TMProject/RenderDevice.cpp
+++ b/Projects/TMProject/RenderDevice.cpp
@@ -949,6 +949,7 @@ int RenderDevice::InitVertexShader()
 			int nLength = _filelength(handle);
 			D3DXCreateBuffer(nLength, &pCode);
 			_read(handle, pCode->GetBufferPointer(), pCode->GetBufferSize());
+			_close(handle);
 
 			if (FAILED(m_pd3dDevice->CreateVertexDeclaration(VertexDecl[i % 4], &m_pVertexDeclaration[i])))
 				return 0;

--- a/Projects/TMProject/TMObjectContainer.cpp
+++ b/Projects/TMProject/TMObjectContainer.cpp
@@ -79,6 +79,7 @@ int TMObjectContainer::Load(const char* szFileName)
 	}
 
 	_read(Handle, buff, sz);
+	_close(Handle);
 
 	int nCheckSum = 0;
 	int sz1 = 28;


### PR DESCRIPTION
Some files remain locked until the application is closed because the _close method is never called.
This commit just fixes this issue, but ideally, we should use RAII mechanism, refactoring to use std::fstream or equivalent.