### PR TITLE
fixed wrong variable name of rgb color tones

### DIFF
--- a/Projects/TMProject/TMSkillTownPortal.cpp
+++ b/Projects/TMProject/TMSkillTownPortal.cpp
@@ -109,7 +109,7 @@ int TMSkillTownPortal::FrameMove(unsigned int dwServerTime)
 
     for (int i = 0; i < nCount; ++i)
     {
-        unsigned int dwR = (unsigned int)((float)m_dwA * fDif) << 16;
+        unsigned int dwR = (unsigned int)((float)m_dwR * fDif) << 16;
         unsigned int dwG = (unsigned int)((float)m_dwG * fDif) << 8;
         unsigned int dwB = (unsigned int)((float)m_dwB * fDif);
         pVertex[i].diffuse = dwB | dwG | dwR;


### PR DESCRIPTION
Usa a variável correta na hora de setar a cor do efeito de teleporte.
Como as cores deveriam ser RGB, devemos usar as respectivas variáveis